### PR TITLE
Ending directory paths with slashes causes install to fail in Windows…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-graft src/
-prune src/jNlp/.git/
+graft src
+prune src/jNlp/.git
 exclude src/jNlp/jnlp/upload.sh
 exclude push.sh
 exclude src/jNlp/*.p

--- a/src/jProcessing.egg-info/SOURCES.txt
+++ b/src/jProcessing.egg-info/SOURCES.txt
@@ -1,7 +1,7 @@
 MANIFEST.in
 README
 setup.py
-scripts/
+scripts
 scripts/vcabocha.py
 src/jNlp/__init__.py
 src/jNlp/eProcessing.py


### PR DESCRIPTION
…; removed slashes from offending path names